### PR TITLE
Codingwatching patch 1

### DIFF
--- a/Assets/Scripts/Managers/SaveManager.cs
+++ b/Assets/Scripts/Managers/SaveManager.cs
@@ -10,7 +10,7 @@ public class SaveManager : NetworkBehaviour
 {
     public static float AutosaveDuration = 2;
     public static Dictionary<Location, string> blockChanges = new Dictionary<Location, string>();
-
+    public static char separatorChar = Path.DirectorySeparatorChar;
     private void Start()
     {
         if (isServer)
@@ -88,10 +88,10 @@ public class SaveManager : NetworkBehaviour
             if (!currentEditingChunk.HasBeenSaved())
                 currentEditingChunk.CreateChunkPath();
 
-            string chunkPath = WorldManager.world.GetPath() + "\\chunks\\" + currentEditingChunk.dimension + "\\" +
+            string chunkPath = WorldManager.world.GetPath() + $"{separatorChar}chunks{separatorChar}" + currentEditingChunk.dimension + separatorChar +
                                currentEditingChunk.chunkX;
 
-            foreach (string line in File.ReadAllLines(chunkPath + "\\blocks")
+            foreach (string line in File.ReadAllLines(chunkPath + $"{separatorChar}blocks")
             ) //Add all old block changes, removing duplicates of new block changes
             {
                 Location lineLoc = new Location(int.Parse(line.Split('*')[0].Split(',')[0]),
@@ -103,10 +103,10 @@ public class SaveManager : NetworkBehaviour
             }
 
             //Empty file before writing
-            File.WriteAllText(chunkPath + "\\blocks", "");
+            File.WriteAllText(chunkPath + $"{separatorChar}blocks", "");
 
             //Write all block changes
-            TextWriter c = new StreamWriter(chunkPath + "\\blocks");
+            TextWriter c = new StreamWriter(chunkPath + $"{separatorChar}blocks");
             foreach (KeyValuePair<Location, string> line in changesForChunk)
                 c.WriteLine(line.Key.x + "," + line.Key.y + "*" + line.Value);
 

--- a/Assets/Scripts/Player/Inventory/Inventory.cs
+++ b/Assets/Scripts/Player/Inventory/Inventory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Mirror;
@@ -20,7 +20,8 @@ public class Inventory : NetworkBehaviour
     public GameObject inventoryMenuPrefab;
 
     public SyncList<ItemStack> items = new SyncList<ItemStack>();
-
+    
+    public static char separatorChar = Path.DirectorySeparatorChar;
     private void Start()
     {
         WorldManager.instance.loadedInventories[id] = this;
@@ -66,7 +67,7 @@ public class Inventory : NetworkBehaviour
         if (WorldManager.instance.loadedInventories.ContainsKey(id))
             return WorldManager.instance.loadedInventories[id];
 
-        if (NetworkServer.active && Directory.Exists(WorldManager.world.GetPath() + "\\inventories\\" + id))
+        if (NetworkServer.active && Directory.Exists(WorldManager.world.GetPath() + $"{separatorChar}inventories{separatorChar}" + id))
             return Load(id);
 
         Debug.LogError("Failed getting inventory with id '" + id + "'");
@@ -85,37 +86,37 @@ public class Inventory : NetworkBehaviour
     [Server]
     public void Save()
     {
-        string path = WorldManager.world.GetPath() + "\\inventories\\" + id;
+        string path = WorldManager.world.GetPath() + $"{separatorChar}inventories{separatorChar}" + id;
         if (!Directory.Exists(path))
             Directory.CreateDirectory(path);
 
-        if (!File.Exists(path + "\\items.dat"))
-            File.Create(path + "\\items.dat").Close();
-        if (!File.Exists(path + "\\type.dat"))
-            File.Create(path + "\\type.dat").Close();
-        if (!File.Exists(path + "\\invName.dat"))
-            File.Create(path + "\\invName.dat").Close();
-        if (!File.Exists(path + "\\size.dat"))
-            File.Create(path + "\\size.dat").Close();
+        if (!File.Exists(path + $"{separatorChar}items.dat"))
+            File.Create(path + $"{separatorChar}items.dat").Close();
+        if (!File.Exists(path + $"{separatorChar}type.dat"))
+            File.Create(path + $"{separatorChar}type.dat").Close();
+        if (!File.Exists(path + $"{separatorChar}invName.dat"))
+            File.Create(path + $"{separatorChar}invName.dat").Close();
+        if (!File.Exists(path + $"{separatorChar}size.dat"))
+            File.Create(path + $"{separatorChar}size.dat").Close();
 
         List<string> itemLines = new List<string>();
         foreach (ItemStack item in items)
             itemLines.Add(item.GetSaveString());
-        File.WriteAllLines(path + "\\items.dat", itemLines);
+        File.WriteAllLines(path +  $"{separatorChar}items.dat", itemLines);
 
-        File.WriteAllLines(path + "\\type.dat", new List<string> {type});
+        File.WriteAllLines(path +  $"{separatorChar}type.dat", new List<string> {type});
 
-        File.WriteAllLines(path + "\\invName.dat", new List<string> {invName});
+        File.WriteAllLines(path +  $"{separatorChar}invName.dat", new List<string> {invName});
 
-        File.WriteAllLines(path + "\\size.dat", new List<string> {size.ToString()});
+        File.WriteAllLines(path +  $"{separatorChar}size.dat", new List<string> {size.ToString()});
     }
 
     [Server]
     public static Inventory Load(int id)
     {
-        string path = WorldManager.world.GetPath() + "\\inventories\\" + id;
+        string path = WorldManager.world.GetPath() +  $"{separatorChar}inventories{separatorChar}" + id;
 
-        string[] itemLines = File.ReadAllLines(path + "\\items.dat");
+        string[] itemLines = File.ReadAllLines(path +  $"{separatorChar}items.dat");
         List<ItemStack> items = new List<ItemStack>();
         foreach (string itemLine in itemLines)
         {
@@ -130,9 +131,9 @@ public class Inventory : NetworkBehaviour
             }
         }
         
-        string type = File.ReadAllLines(path + "\\type.dat")[0];
-        string invName = File.ReadAllLines(path + "\\invName.dat")[0];
-        int size = int.Parse(File.ReadAllLines(path + "\\size.dat")[0]);
+        string type = File.ReadAllLines(path +  $"{separatorChar}type.dat")[0];
+        string invName = File.ReadAllLines(path +  $"{separatorChar}invName.dat")[0];
+        int size = int.Parse(File.ReadAllLines(path +  $"{separatorChar}size.dat")[0]);
 
         Inventory inv = Create(type, size, invName, id);
         inv.items.Clear();
@@ -144,7 +145,7 @@ public class Inventory : NetworkBehaviour
     [Server]
     public void Delete()
     {
-        string path = WorldManager.world.GetPath() + "\\inventories\\" + id;
+        string path = WorldManager.world.GetPath() +  $"{separatorChar}inventories{separatorChar}" + id;
         Directory.Delete(path, true);
         NetworkServer.Destroy(gameObject);
     }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -54,7 +54,8 @@ public class Player : HumanEntity
     //Entity Properties
     public override bool ChunkLoadingEntity { get; } = true;
     public override float maxHealth { get; } = 20;
-
+    
+    public static char separatorChar = Path.DirectorySeparatorChar;
     public override void Start()
     {
         Debug.Log("Spawning player '" + uuid + "'");
@@ -723,8 +724,8 @@ public class Player : HumanEntity
     [Server]
     public override void Save()
     {
-        if (!Directory.Exists(WorldManager.world.GetPath() + "\\players\\" + displayName))
-            Directory.CreateDirectory(WorldManager.world.GetPath() + "\\players\\" + displayName);
+        if (!Directory.Exists(WorldManager.world.GetPath() + $"{separatorChar}players{separatorChar}" + displayName))
+            Directory.CreateDirectory(WorldManager.world.GetPath() + $"{separatorChar}players{separatorChar}" + displayName);
 
         base.Save();
         PlayerSaveData.SetBedLocation(displayName, bedLocation);
@@ -751,7 +752,7 @@ public class Player : HumanEntity
     [Server]
     public override string SavePath()
     {
-        return WorldManager.world.GetPath() + "\\players\\" + uuid + "\\entity.dat";
+        return WorldManager.world.GetPath() + $"{separatorChar}players{separatorChar}" + uuid + $"{separatorChar}entity.dat";
     }
 
     [Server]

--- a/Assets/Scripts/Player/PlayerSaveData.cs
+++ b/Assets/Scripts/Player/PlayerSaveData.cs
@@ -1,17 +1,18 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
 public class PlayerSaveData
 {
+    public static char separatorChar = Path.DirectorySeparatorChar;
     public static string GetPath()
     {
-        return WorldManager.world.GetPath() + "\\players";
+        return WorldManager.world.GetPath() + $"{separatorChar}players";
     }
 
     public static string GetPlayerPath(string Player)
     {
-        return GetPath() + "\\" + Player + "\\playerData.dat";
+        return GetPath() + separatorChar + Player + $"{separatorChar}playerData.dat";
     }
 
     public static void SetBedLocation(string player, Location loc)

--- a/Assets/Scripts/World/Chunk/Chunk.cs
+++ b/Assets/Scripts/World/Chunk/Chunk.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -48,7 +48,8 @@ public class Chunk : NetworkBehaviour
 
     public WorldGenerator worldGenerator;
 
-
+    public static char separatorChar = Path.DirectorySeparatorChar;
+    
     private void Start()
     {
         if (isServer)
@@ -167,8 +168,8 @@ public class Chunk : NetworkBehaviour
     [Server]
     private IEnumerator LoadBlocks()
     {
-        string path = WorldManager.world.GetPath() + "\\chunks\\" + chunkPosition.dimension + "\\" +
-                      chunkPosition.chunkX + "\\blocks";
+        string path = WorldManager.world.GetPath() + $"{separatorChar}chunks{separatorChar}" + chunkPosition.dimension + $"{separatorChar}" +
+                      chunkPosition.chunkX + $"{separatorChar}blocks";
 
         string[] lines = File.ReadAllLines(path);
         foreach (string line in lines)
@@ -243,8 +244,8 @@ public class Chunk : NetworkBehaviour
 
 
         //Mark chunk as Generated
-        string chunkDataPath = WorldManager.world.GetPath() + "\\chunks\\" + chunkPosition.dimension + "\\" +
-                               chunkPosition.chunkX + "\\chunk";
+        string chunkDataPath = WorldManager.world.GetPath() + $"{separatorChar}chunks{separatorChar}" + chunkPosition.dimension + $"{separatorChar}" +
+                               chunkPosition.chunkX + $"{separatorChar}chunk";
         List<string> chunkDataLines = File.ReadAllLines(chunkDataPath).ToList();
         chunkDataLines.Add("hasBeenGenerated=true");
         File.WriteAllLines(chunkDataPath, chunkDataLines);
@@ -423,12 +424,12 @@ public class Chunk : NetworkBehaviour
             presentUuids.Add(entity.uuid);
         }
         
-        string path = WorldManager.world.GetPath() + "\\chunks\\" + chunkPosition.dimension + "\\" +
+        string path = WorldManager.world.GetPath() + $"{separatorChar}chunks{separatorChar}" + chunkPosition.dimension + $"{separatorChar}" +
                       chunkPosition.chunkX +
-                      "\\entities";
+                      $"{separatorChar}entities";
         foreach (string entityPath in Directory.GetFiles(path))
         {
-            string entityFile = entityPath.Split('\\')[entityPath.Split('\\').Length - 1];
+            string entityFile = entityPath.Split(separatorChar)[entityPath.Split(separatorChar).Length - 1];
             string entityUuid = entityFile.Split('.')[0];
 
             if(!presentUuids.Contains(entityUuid))
@@ -624,16 +625,16 @@ public class Chunk : NetworkBehaviour
     [Server]
     private void LoadAllEntities()
     {
-        string path = WorldManager.world.GetPath() + "\\chunks\\" + chunkPosition.dimension + "\\" +
+        string path = WorldManager.world.GetPath() + $"{separatorChar}chunks{separatorChar}" + chunkPosition.dimension + $"{separatorChar}" +
                       chunkPosition.chunkX +
-                      "\\entities";
+                      $"{separatorChar}entities";
 
         if (!Directory.Exists(path))
             return;
 
         foreach (string entityPath in Directory.GetFiles(path))
         {
-            string entityFile = entityPath.Split('\\')[entityPath.Split('\\').Length - 1];
+            string entityFile = entityPath.Split(separatorChar)[entityPath.Split(separatorChar).Length - 1];
             string entityType = entityFile.Split('.')[1];
             string entityUuid = entityFile.Split('.')[0];
 

--- a/Assets/Scripts/World/Chunk/Chunk.cs
+++ b/Assets/Scripts/World/Chunk/Chunk.cs
@@ -47,7 +47,6 @@ public class Chunk : NetworkBehaviour
     [SyncVar] public ChunkPosition chunkPosition;
 
     public WorldGenerator worldGenerator;
-
     public static char separatorChar = Path.DirectorySeparatorChar;
     
     private void Start()

--- a/Assets/Scripts/World/Chunk/ChunkPosition.cs
+++ b/Assets/Scripts/World/Chunk/ChunkPosition.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using Mirror;
 using UnityEngine;
 
@@ -8,6 +8,7 @@ public struct ChunkPosition
     public Dimension dimension;
     public int worldX => chunkX * Chunk.Width;
 
+    public static char separatorChar = Path.DirectorySeparatorChar;
     public ChunkPosition(int chunkX, Dimension dimension)
     {
         this.chunkX = chunkX;
@@ -28,7 +29,7 @@ public struct ChunkPosition
 
     public bool HasBeenSaved()
     {
-        string path = WorldManager.world.GetPath() + "\\chunks\\" + dimension + "\\" + chunkX;
+        string path = WorldManager.world.GetPath() + $"{separatorChar}chunks{separatorChar}" + dimension + $"{separatorChar}" + chunkX;
 
         return Directory.Exists(path);
     }
@@ -38,7 +39,7 @@ public struct ChunkPosition
         if (!HasBeenSaved())
             return false;
 
-        string chunkDataPath = WorldManager.world.GetPath() + "\\chunks\\" + dimension + "\\" + chunkX + "\\chunk";
+        string chunkDataPath = WorldManager.world.GetPath() + $"{separatorChar}chunks{separatorChar}" + dimension + $"{separatorChar}" + chunkX + $"{separatorChar}chunk";
         string[] chunkDataLines = File.ReadAllLines(chunkDataPath);
         foreach (string line in chunkDataLines)
             if (line.Contains("hasBeenGenerated"))
@@ -82,13 +83,13 @@ public struct ChunkPosition
 
     public void CreateChunkPath()
     {
-        string path = WorldManager.world.GetPath() + "\\chunks\\" + dimension + "\\" + chunkX;
+        string path = WorldManager.world.GetPath() + $"{separatorChar}chunks{separatorChar}" + dimension + $"{separatorChar}" + chunkX;
         if (!Directory.Exists(path))
         {
             Directory.CreateDirectory(path);
-            Directory.CreateDirectory(path + "\\entities");
-            File.Create(path + "\\blocks").Close();
-            File.Create(path + "\\chunk").Close();
+            Directory.CreateDirectory(path + $"{separatorChar}entities");
+            File.Create(path + $"{separatorChar}blocks").Close();
+            File.Create(path + $"{separatorChar}chunk").Close();
         }
     }
 

--- a/Assets/Scripts/World/World.cs
+++ b/Assets/Scripts/World/World.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
@@ -12,7 +12,7 @@ public class World
     public int seed;
     public float time;
     public int versionId;
-
+    public static char separatorChar = Path.DirectorySeparatorChar;
     public World(string name, int seed)
     {
         this.name = name;
@@ -39,7 +39,7 @@ public class World
     {
         World world = new World(name, 0);
         Dictionary<string, string> worldData = new Dictionary<string, string>();
-        string[] data = File.ReadAllLines(world.GetPath() + "\\level.dat");
+        string[] data = File.ReadAllLines(world.GetPath() + $"{separatorChar}level.dat");
         foreach (string dataLine in data)
             worldData.Add(dataLine.Split('=')[0], dataLine.Split('=')[1]);
 
@@ -52,7 +52,7 @@ public class World
 
     public static bool WorldExists(string name)
     {
-        return File.Exists(new World(name, 0).GetPath() + "\\level.dat");
+        return File.Exists(new World(name, 0).GetPath() + $"{separatorChar}level.dat");
     }
 
     public static List<World> LoadWorlds()
@@ -60,7 +60,7 @@ public class World
         List<World> worlds = new List<World>();
 
         foreach (string worldName in Directory.GetDirectories(GetSavesPath()))
-            worlds.Add(LoadWorld(worldName.Split('\\')[worldName.Split('\\').Length - 1]));
+            worlds.Add(LoadWorld(worldName.Split(separatorChar)[worldName.Split(separatorChar).Length - 1]));
 
         return worlds;
     }
@@ -74,17 +74,17 @@ public class World
     {
         if (!Directory.Exists(GetPath()))
             Directory.CreateDirectory(GetPath());
-        if (!Directory.Exists(GetPath() + "\\chunks"))
-            Directory.CreateDirectory(GetPath() + "\\chunks");
-        if (!Directory.Exists(GetPath() + "\\chunks\\Overworld"))
-            Directory.CreateDirectory(GetPath() + "\\chunks\\Overworld");
-        if (!Directory.Exists(GetPath() + "\\chunks"))
-            Directory.CreateDirectory(GetPath() + "\\players");
-        if (!Directory.Exists(GetPath() + "\\inventories"))
-            Directory.CreateDirectory(GetPath() + "\\inventories");
+        if (!Directory.Exists(GetPath() + $"{separatorChar}chunks"))
+            Directory.CreateDirectory(GetPath() + $"{separatorChar}chunks");
+        if (!Directory.Exists(GetPath() + $"{separatorChar}chunks{separatorChar}Overworld"))
+            Directory.CreateDirectory(GetPath() + $"{separatorChar}chunks{separatorChar}Overworld");
+        if (!Directory.Exists(GetPath() + $"{separatorChar}chunks"))
+            Directory.CreateDirectory(GetPath() + $"{separatorChar}players");
+        if (!Directory.Exists(GetPath() + $"{separatorChar}inventories"))
+            Directory.CreateDirectory(GetPath() + $"{separatorChar}inventories");
 
-        if (!File.Exists(GetPath() + "\\level.dat"))
-            File.Create(GetPath() + "\\level.dat").Close();
+        if (!File.Exists(GetPath() + $"{separatorChar}level.dat"))
+            File.Create(GetPath() + $"{separatorChar}level.dat").Close();
 
         List<string> data = new List<string>();
 
@@ -92,12 +92,12 @@ public class World
         data.Add("time=" + time);
         data.Add("versionId=" + versionId);
 
-        File.WriteAllLines(GetPath() + "\\level.dat", data);
+        File.WriteAllLines(GetPath() + $"{separatorChar}level.dat", data);
     }
 
     public static string GetSavesPath()
     {
-        string savesPath = appPath + "\\..\\Saves\\";
+        string savesPath = appPath + $"{separatorChar}..{separatorChar}Saves{separatorChar}";
 
         if (!Directory.Exists(savesPath))
             Directory.CreateDirectory(savesPath);


### PR DESCRIPTION
Use Path.DirectorySeparatorChar instead of '\\' to prevent the wrong path on MacOS

